### PR TITLE
Changed settings config to object style. Do time calculation for expires...

### DIFF
--- a/lib/browser_fingerprint.js
+++ b/lib/browser_fingerprint.js
@@ -58,8 +58,34 @@ var browser_fingerprint = {
 			var cookeHash = {};
 			if(options.toSetCookie == true){
 				if (options.settings != undefined) {
-					// Settings must be in proper cookie format, IE: options.settings="path=/;secure=yes;expire=12345"
-					cookeHash = {'Set-Cookie': options.cookieKey + '=' + fingerprint + ';' + options.settings };
+					var settings = options.settings;
+					var settingsParams = '';
+					/*
+					new version in object format e.g.
+						settings            : {
+							path              : '/',
+							expires           : 86400000
+						}
+
+					old version till v0.0.4 e.g.
+						settings :'path=/;expires=' + new Date(new Date().getTime() + 86400000).toUTCString()+';'
+					*/
+
+					/* Check to be compatible to both version */
+					if(typeof(settings) == 'object') {
+						for (var key in settings) {
+							if (settings.hasOwnProperty(key)) {
+								var value = settings[key];
+								if(key === 'expires') {
+									value = new Date(new Date().getTime() + settings[key]).toUTCString();
+								}
+								settingsParams = settingsParams + key + '=' + value + ';';
+							}
+						}
+					} else {
+						settingsParams = settings;
+					}
+					cookeHash = {'Set-Cookie': options.cookieKey + '=' + fingerprint + ';' + settingsParams };
 				} else {
 					cookeHash = {'Set-Cookie': options.cookieKey + '=' + fingerprint };
 				}


### PR DESCRIPTION
New config style:

``` javascript
        fingerprintOptions    : {
          cookieKey           : 'appHeroID',
          toSetCookie         : true,
          onlyStaticElements  : false,
          settings            : {
            path              : '/',
            expires           : 86400000
          }
        }
```

Expires in ms, correct date (UTC) will be calculated automatically. Old version doesn't work correctly, because config is only read once. 
