### PR TITLE
Small README example constructor property fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const fingerPrinter = new BrowserFingerprint(options);
 
 http
   .createServer((req, res) => {
-    let { fingerprint, elementHash, headersHash } = fingerPrinter.fingerprint(
+    let { fingerprint, elementsHash, headersHash } = fingerPrinter.fingerprint(
       req
     );
     headersHash["Content-Type"] = "text/plain"; // append any other headers you want

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Resuming sessions require that either the cookie be returned to the server, or a
 const http = require("http");
 const port = 8080;
 
-const BrowserFingerprint = require("browser_fingerprint");
+const BrowserFingerprint = require("browser_fingerprint").BrowserFingerprint;
 
 // these are the default options
 const options = {


### PR DESCRIPTION
As _dist/browserFingerpint.js_ exports the BrowserFingerprint constructor as `exports.BrowserFingerprint = BrowserFingerprint;` , we need to match that property name when importing with `require("browser_fingerprint").BrowserFingerprint`.
An alternative would be to make the BrowserFingerprint constructor the default constructor with `exports = BrowserFingerprint;`.
An explanation is given [here](https://stackoverflow.com/questions/39432687/node-js-class-is-not-a-constructor).